### PR TITLE
quote values inside jekyll header with double quote

### DIFF
--- a/org-jekyll.el
+++ b/org-jekyll.el
@@ -178,7 +178,7 @@ language.")
           (when yaml-front-matter
             (insert "---\n")
             (mapc (lambda (pair)
-                    (insert (format "%s: %s\n" (car pair) (cdr pair))))
+                    (insert (format "%s: \"%s\"\n" (car pair) (cdr pair))))
                   yaml-front-matter)
             (if (and org-jekyll-localize-dir lang)
                 (mapc (lambda (line)


### PR DESCRIPTION
generate header like this,

```

---
titile: "abc"
on: "2013-05-13"
```

so that title like "introduction: colon" won't break things. :)
