### PR TITLE
Enclose the YAML front matter values in double quotes

### DIFF
--- a/org-jekyll.el
+++ b/org-jekyll.el
@@ -182,7 +182,7 @@ language.")
           (when yaml-front-matter
             (insert "---\n")
             (mapc (lambda (pair)
-                    (insert (format "%s: %s\n" (car pair) (cdr pair))))
+                    (insert (format "%s: \"%s\"\n" (car pair) (cdr pair))))
                   yaml-front-matter)
             (if (and org-jekyll-localize-dir lang)
                 (mapc (lambda (line)


### PR DESCRIPTION
which allows characters such colons in the title.

I had a blog post title that contained a colon and Jekyll chokes on that, but if YAML values are enclosed with double quotes, it works.